### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/playwright.yml
+++ b/.github/workflows/playwright.yml
@@ -1,4 +1,6 @@
 name: Playwright Tests
+permissions:
+  contents: read
 on:
   push:
     branches: [ main, master ]


### PR DESCRIPTION
Potential fix for [https://github.com/RobertPecz/PlaywrightPetProject/security/code-scanning/1](https://github.com/RobertPecz/PlaywrightPetProject/security/code-scanning/1)

To address this problem, you should explicitly set the `permissions` key at the appropriate level in the workflow YAML file. In this case, adding `permissions: contents: read` at the workflow root (i.e., at the same indentation level as `name:` and `on:`) is the best way to apply minimal permissions to all jobs unless any job overrides with its own `permissions` block. This does not affect the current workflow functionality, as none of the steps require more than read access to code.

**Implementation steps:**
- Edit `.github/workflows/playwright.yml`
- Insert the following lines after the `name: Playwright Tests` line:
  ```yaml
  permissions:
    contents: read
  ```
- No imports, methods, or other changes are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
