### PR TITLE
feat: Add test for adding multiple products and removing one from cart (#92)

### DIFF
--- a/pages/cartpage.ts
+++ b/pages/cartpage.ts
@@ -16,7 +16,8 @@ class CartPage {
     cartItemCount: () => this.page.locator('//span[@class="cart-qty"]'),
 
     // Item details in cart
-    itemNameInCart: (productName: string) => this.page.locator(`//a[contains(text(), "${productName}")]`),
+    itemNameInCart: (productName: string) =>
+      this.page.locator(`//table[@class="cart"]//a[contains(text(), "${productName}")]`),
     itemQuantityInput: (index: number = 0) => this.page.locator('//input[@class="qty-input"]').nth(index),
     itemRemoveButton: (index: number = 0) => this.page.locator('//button[contains(text(), "Remove")]').nth(index),
 
@@ -92,6 +93,12 @@ class CartPage {
       await this.elements.updateCartButton().click();
       await this.page.waitForLoadState('domcontentloaded');
     }
+  }
+
+  async removeItemByIndex(index: number) {
+    await this.elements.removeItemCheckboxes().nth(index).check();
+    await this.elements.updateCartButton().click();
+    await this.page.waitForLoadState('domcontentloaded');
   }
 
   async continueShopping() {

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -282,4 +282,64 @@ test.describe('Buy product tests', () => {
       expect(orderNumber).toBeTruthy();
     });
   });
+
+  test('User can add multiple products to cart and remove one (#92)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let firstProductName: string;
+    let secondProductName: string;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      firstProductName = (await productPage.elements.productTitle().innerText()).trim();
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify first product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to Computers and add second product to cart', async () => {
+      await productPage.navigateToCategory('Computers');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      secondProductName = (await productPage.elements.productTitle().innerText()).trim();
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify second product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Open cart and verify both products are present', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      const count = await cartPage.getCartItemsCount();
+      expect(count).toBeGreaterThanOrEqual(2);
+      await expect(cartPage.elements.itemNameInCart(firstProductName)).toBeVisible();
+      await expect(cartPage.elements.itemNameInCart(secondProductName)).toBeVisible();
+    });
+
+    await test.step('Remove the second product from cart', async () => {
+      await cartPage.removeItemByIndex(1);
+    });
+
+    await test.step('Verify only the removed product is missing from cart', async () => {
+      const count = await cartPage.getCartItemsCount();
+      expect(count).toBe(1);
+      await expect(cartPage.elements.itemNameInCart(firstProductName)).toBeVisible();
+      await expect(cartPage.elements.itemNameInCart(secondProductName)).not.toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Added new test: **User can add multiple products to cart and remove one** in `tests/buyproduct.spec.ts`
- Adds Books + Computers products, verifies both are in cart, removes the second by index, then asserts only the removed product is missing
- Added `CartPage.removeItemByIndex(index)` helper method to `pages/cartpage.ts`
- Fixed `CartPage.itemNameInCart()` selector to scope to the cart table (avoids strict-mode violation from the flyout mini-cart in the header)

## Test Results

✓ 12/12 buyproduct tests passing (3 browsers × 4 tests)

## Related Issues

Close #92

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Fresh registration per test run (avoids parallel cart conflicts)
- [x] Related GitHub issue referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)