### PR TITLE
feat: Add test for adding product to cart from list view (fixes #97)

### DIFF
--- a/pages/productpage.ts
+++ b/pages/productpage.ts
@@ -28,6 +28,10 @@ class ProductPage {
     quantityInput: () => this.page.locator("input[id*='EnteredQuantity']"),
     addToCartButton: () => this.page.locator("//input[contains(@id, 'add-to-cart-button')]"),
 
+    // List view add-to-cart button (on category/listing page, scoped per item index)
+    addToCartFromListViewButton: (index: number = 0) =>
+      this.page.locator('input.product-box-add-to-cart-button').nth(index),
+
     // Success notification
     successMessage: () => this.page.locator('//p[@class="content"]'),
     closeSuccessButton: () => this.page.locator('//span[@class="close"]').first(),
@@ -81,6 +85,11 @@ class ProductPage {
   async addToCartWithQuantity(quantity: number) {
     await this.setQuantity(quantity);
     await this.addProductToCart();
+  }
+
+  async addToCartFromListView(index: number = 0) {
+    await this.elements.addToCartFromListViewButton(index).click();
+    await this.elements.successMessage().waitFor({ state: 'visible', timeout: 15000 });
   }
 
   async closeSuccessNotification() {

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -528,6 +528,40 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User can add product to cart from list view (#97)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books category', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.addToCartFromListViewButton(0)).toBeVisible();
+    });
+
+    await test.step('Add first product to cart directly from list view without opening product page', async () => {
+      await productPage.addToCartFromListView(0);
+    });
+
+    await test.step('Verify product was successfully added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and verify product is present', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      const itemCount = await cartPage.getCartItemsCount();
+      expect(itemCount).toBeGreaterThan(0);
+    });
+  });
+
   test('User can add multiple products to cart and remove one (#92)', async ({ page }) => {
     const mainPage = new MainPage(page);
     let productPage: ProductPage;


### PR DESCRIPTION
## Summary

- Added `addToCartFromListViewButton` element and `addToCartFromListView()` method to `ProductPage`
- Added test _'User can add product to cart from list view (#97)'_ to `buyproduct.spec.ts`
- Test validates that a user can add a product directly from the category listing page without navigating to the product detail page

## Test Results

✓ 30/30 tests passing (Chromium, Firefox, WebKit)

## Related Issues

Fixes #97

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)