### PR TITLE
feat: Add test for checkout with no default shipping address (fixes #99)

### DIFF
--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -562,6 +562,78 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User can proceed through checkout without explicitly selecting shipping address when no default address exists (#99)', async ({
+    page,
+  }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let checkoutPage: CheckoutPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and proceed to checkout', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      await cartPage.proceedToCheckout();
+    });
+
+    await test.step('Verify billing address form is visible for new user and fill billing address', async () => {
+      checkoutPage = new CheckoutPage(page);
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+      await checkoutPage.fillBillingAddress({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: userEmail,
+        country: 'United States',
+        city: 'New York',
+        address: '123 Main Street',
+        zipCode: '10001',
+        phone: '+1 (212) 555-0100',
+      });
+    });
+
+    await test.step('Proceed through checkout without explicitly selecting shipping address', async () => {
+      // Continue past billing (saves address, opens shipping address step)
+      await checkoutPage.proceedToNextStep();
+      // Skip explicit shipping address selection — billing address is auto-selected as the only option
+      await checkoutPage.proceedToNextStep();
+      await checkoutPage.selectShippingMethod('Ground');
+      await checkoutPage.proceedToNextStep();
+      await checkoutPage.selectPaymentMethod('Credit Card');
+      await checkoutPage.proceedToNextStep();
+      await checkoutPage.proceedToNextStep();
+    });
+
+    await test.step('Confirm the order', async () => {
+      await checkoutPage.confirmOrder();
+    });
+
+    await test.step('Verify order was successfully placed', async () => {
+      const isConfirmed = await checkoutPage.isOrderConfirmed();
+      expect(isConfirmed).toBeTruthy();
+      const orderNumber = await checkoutPage.getOrderNumber();
+      expect(orderNumber).toBeTruthy();
+    });
+  });
+
   test('User can add multiple products to cart and remove one (#92)', async ({ page }) => {
     const mainPage = new MainPage(page);
     let productPage: ProductPage;


### PR DESCRIPTION
## Summary

- Added 1 test to `tests/buyproduct.spec.ts` covering TC 002-13
- Verifies billing address form appears directly for a fresh user with no saved addresses
- Verifies checkout completes without explicitly selecting a shipping address (auto-selects the only saved address)

## Test Results

✓ 3 tests passing (Chromium, Firefox, WebKit)

## Related Issues

Fixes #99

## Checklist

- [x] All tests passing
- [x] Test spec follows project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)