### PR TITLE
feat: Add test for adding product to cart from details view (fixes #98)

### DIFF
--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -562,6 +562,45 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User can add product to cart from details view (#98)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books category', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+    });
+
+    await test.step('Open product detail page by clicking the first product', async () => {
+      await productPage.selectProductByIndex(0);
+      await expect(productPage.elements.productTitle()).toBeVisible();
+    });
+
+    await test.step('Add product to cart from the product detail page', async () => {
+      await productPage.addProductToCart();
+    });
+
+    await test.step('Verify product was successfully added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and verify product is present', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      const itemCount = await cartPage.getCartItemsCount();
+      expect(itemCount).toBeGreaterThan(0);
+    });
+  });
+
   test('User can proceed through checkout without explicitly selecting shipping address when no default address exists (#99)', async ({
     page,
   }) => {


### PR DESCRIPTION
## Summary

- Added 1 test to `tests/buyproduct.spec.ts`
- No new page objects needed — all required methods already existed
- 3 tests passing (Chromium, Firefox, WebKit)

## Test coverage

- Navigate to product listing → open product detail page → add to cart from detail page → verify cart contains product
- Distinct from #97 (list view): this test clicks into the detail page first via `selectProductByIndex()` before adding to cart

## Test Results

✓ 3/3 tests passing across all browsers

## Related Issues

Fixes #98

## Checklist

- [x] All tests passing
- [x] Test spec follows project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)