### PR TITLE
feat: Add test for checkout with terms and conditions not accepted (fixes #102)

### DIFF
--- a/pages/cartpage.ts
+++ b/pages/cartpage.ts
@@ -38,6 +38,10 @@ class CartPage {
 
     // tos checkbox
     tosCheckbox: () => this.page.locator('#termsofservice'),
+
+    // tos error modal (shown when checkout is attempted without accepting TOS)
+    tosErrorDialog: () => this.page.getByRole('dialog', { name: 'Terms of service' }),
+    tosErrorMessage: () => this.page.getByRole('dialog', { name: 'Terms of service' }).locator('p'),
   };
 
   async openCart() {
@@ -75,6 +79,12 @@ class CartPage {
     await this.elements.checkoutButton().click();
     await this.page.waitForURL(/checkout|onepagecheckout/, { timeout: 10000 }).catch(() => {});
     await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async attemptCheckoutWithoutTOS(): Promise<string> {
+    await this.elements.checkoutButton().click();
+    await this.elements.tosErrorDialog().waitFor({ state: 'visible', timeout: 5000 });
+    return await this.elements.tosErrorMessage().innerText();
   }
 
   async isCartEmpty(): Promise<boolean> {

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -906,4 +906,40 @@ test.describe('Buy product tests', () => {
       await expect(cartPage.elements.itemNameInCart(secondProductName)).not.toBeVisible();
     });
   });
+
+  test('User cannot proceed to checkout without accepting terms and conditions (#102)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and attempt checkout without accepting terms', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      const alertMessage = await cartPage.attemptCheckoutWithoutTOS();
+      expect(alertMessage).toContain('terms of service');
+    });
+
+    await test.step('Verify user remains on cart page and has not proceeded to checkout', async () => {
+      await expect(page).toHaveURL(/\/cart/);
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Added `attemptCheckoutWithoutTOS()` method and TOS error dialog elements to `CartPage`
- Added test verifying the user cannot proceed to checkout without accepting terms and conditions
- Asserts the custom modal dialog appears with the expected message and the user stays on the cart page

## Test Results

✓ 3 tests passing (Chromium, Firefox, WebKit)

## Changes

- `pages/cartpage.ts` — added `tosErrorDialog` and `tosErrorMessage` elements; added `attemptCheckoutWithoutTOS()` method that clicks checkout without checking TOS and waits for the HTML modal
- `tests/buyproduct.spec.ts` — added test `User cannot proceed to checkout without accepting terms and conditions (#102)`

## Related Issues

Fixes #102

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow AAA pattern with `test.step`
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)