### PR TITLE
feat: Add test for checkout with last name not filled (fixes #104)

### DIFF
--- a/pages/checkoutpage.ts
+++ b/pages/checkoutpage.ts
@@ -39,6 +39,9 @@ class CheckoutPage {
     // Shipping address selector (step 2 of OPC)
     shippingAddressSelect: () => this.page.locator('select[name="shipping_address_id"]'),
 
+    // Billing address validation errors
+    billingLastNameError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.LastName"]'),
+
     // Guest checkout button (shown when not logged in)
     checkoutAsGuestButton: () => this.page.locator('input.checkout-as-guest-button, input[value="Checkout as Guest"]'),
 

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -907,6 +907,63 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User cannot proceed to checkout with billing last name not filled (#104)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let checkoutPage: CheckoutPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and proceed to checkout', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      await cartPage.proceedToCheckout();
+    });
+
+    await test.step('Fill billing address with last name intentionally left empty', async () => {
+      checkoutPage = new CheckoutPage(page);
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+      await checkoutPage.fillBillingAddress({
+        firstName: 'John',
+        lastName: '',
+        email: userEmail,
+        country: 'United States',
+        city: 'New York',
+        address: '123 Main Street',
+        zipCode: '10001',
+        phone: '+1 (212) 555-0100',
+      });
+    });
+
+    await test.step('Attempt to proceed without last name and verify error message appears', async () => {
+      await checkoutPage.elements.nextButton().click();
+      await expect(checkoutPage.elements.billingLastNameError()).toBeVisible();
+      await expect(checkoutPage.elements.billingLastNameError()).toContainText('Last name is required.');
+    });
+
+    await test.step('Verify user remains on billing step and cannot proceed', async () => {
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+    });
+  });
+
   test('User cannot proceed to checkout without accepting terms and conditions (#102)', async ({ page }) => {
     const mainPage = new MainPage(page);
     let productPage: ProductPage;


### PR DESCRIPTION
## Summary

- Added `billingLastNameError` element locator to `CheckoutPage` (`pages/checkoutpage.ts`)
- Added test: _User cannot proceed to checkout with billing last name not filled_ to `tests/buyproduct.spec.ts`
- 1 new test × 3 browsers = 3 total new test runs — all passing

## Test Results

✓ 3/3 passing (Chromium, Firefox, WebKit)

## Test case covered

| ID | Title | Expected Result |
|---|---|---|
| 002-18 | Checkout with Last name not filled | User cannot proceed and receives an error message |

## Related Issues

Fixes #104

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)