### PR TITLE
feat: Add test for checkout with country not selected (fixes #106)

### DIFF
--- a/pages/checkoutpage.ts
+++ b/pages/checkoutpage.ts
@@ -43,6 +43,7 @@ class CheckoutPage {
     billingFirstNameError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.FirstName"]'),
     billingLastNameError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.LastName"]'),
     billingEmailError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.Email"]'),
+    billingCountryError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.CountryId"]'),
     billingCityError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.City"]'),
 
     // Guest checkout button (shown when not logged in)
@@ -141,7 +142,7 @@ class CheckoutPage {
     lastName: string;
     email: string;
     company?: string;
-    country: string;
+    country?: string;
     state?: string;
     city: string;
     address: string;
@@ -164,14 +165,16 @@ class CheckoutPage {
       await this.elements.billingCompanyInput().fill(company);
     }
 
-    const countrySelect = this.elements.billingCountrySelect();
-    await countrySelect.selectOption({ label: country });
+    if (country) {
+      const countrySelect = this.elements.billingCountrySelect();
+      await countrySelect.selectOption({ label: country });
 
-    if (state) {
-      const stateSelect = this.elements.billingStateSelect();
-      const stateOptions = await stateSelect.locator('option').allTextContents();
-      if (stateOptions.includes(state)) {
-        await stateSelect.selectOption({ label: state });
+      if (state) {
+        const stateSelect = this.elements.billingStateSelect();
+        const stateOptions = await stateSelect.locator('option').allTextContents();
+        if (stateOptions.includes(state)) {
+          await stateSelect.selectOption({ label: state });
+        }
       }
     }
 

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -1114,6 +1114,62 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User cannot proceed to checkout with billing country not selected (#106)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let checkoutPage: CheckoutPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and proceed to checkout', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      await cartPage.proceedToCheckout();
+    });
+
+    await test.step('Fill billing address with country intentionally left unselected', async () => {
+      checkoutPage = new CheckoutPage(page);
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+      await checkoutPage.fillBillingAddress({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: userEmail,
+        city: 'New York',
+        address: '123 Main Street',
+        zipCode: '10001',
+        phone: '+1 (212) 555-0100',
+      });
+    });
+
+    await test.step('Attempt to proceed without country and verify error message appears', async () => {
+      await checkoutPage.elements.nextButton().click();
+      await expect(checkoutPage.elements.billingCountryError()).toBeVisible();
+      await expect(checkoutPage.elements.billingCountryError()).toContainText('Country is required');
+    });
+
+    await test.step('Verify user remains on billing step and cannot proceed', async () => {
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+    });
+  });
+
   test('User cannot proceed to checkout with billing email not filled (#105)', async ({ page }) => {
     const mainPage = new MainPage(page);
     let productPage: ProductPage;


### PR DESCRIPTION
## Summary

- Added `billingCountryError` element to `CheckoutPage`
- Made `country` optional in `fillBillingAddress` to support testing unselected country
- Added test: User cannot proceed to checkout with billing country not selected
- 3 tests passing across Chromium, Firefox, WebKit

## Test Results

✓ 3/3 tests passing (Chromium, Firefox, WebKit)

## Related Issues

Fixes #106

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)