### PR TITLE
perf: Increase CI workers from 1 to 4 for faster pipeline

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -8,8 +8,7 @@ export default defineConfig({
   forbidOnly: !!process.env.CI,
   /* Retry on CI only */
   retries: process.env.CI ? 2 : 0,
-  /* Opt out of parallel tests on CI. */
-  workers: process.env.CI ? 1 : undefined,
+  workers: process.env.CI ? 4 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
   reporter: 'html',
   /* Shared settings for all the projects below. See https://playwright.dev/docs/api/class-testoptions. */


### PR DESCRIPTION
Tests are network-bound against an external demo site, not CPU-bound, so running 4 parallel workers reduces wall-clock time significantly. This allows the 3 browser variants to run concurrently.