### PR TITLE
feat: Add test for checkout with address1 not filled (fixes #108)

### DIFF
--- a/pages/checkoutpage.ts
+++ b/pages/checkoutpage.ts
@@ -45,6 +45,7 @@ class CheckoutPage {
     billingEmailError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.Email"]'),
     billingCountryError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.CountryId"]'),
     billingCityError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.City"]'),
+    billingAddress1Error: () => this.page.locator('[data-valmsg-for="BillingNewAddress.Address1"]'),
 
     // Guest checkout button (shown when not logged in)
     checkoutAsGuestButton: () => this.page.locator('input.checkout-as-guest-button, input[value="Checkout as Guest"]'),

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -1170,6 +1170,63 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User cannot proceed to checkout with billing address1 not filled (#108)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let checkoutPage: CheckoutPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and proceed to checkout', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      await cartPage.proceedToCheckout();
+    });
+
+    await test.step('Fill billing address with address1 intentionally left empty', async () => {
+      checkoutPage = new CheckoutPage(page);
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+      await checkoutPage.fillBillingAddress({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: userEmail,
+        country: 'United States',
+        city: 'New York',
+        address: '',
+        zipCode: '10001',
+        phone: '+1 (212) 555-0100',
+      });
+    });
+
+    await test.step('Attempt to proceed without address1 and verify error message appears', async () => {
+      await checkoutPage.elements.nextButton().click();
+      await expect(checkoutPage.elements.billingAddress1Error()).toBeVisible();
+      await expect(checkoutPage.elements.billingAddress1Error()).toContainText('Street address is required');
+    });
+
+    await test.step('Verify user remains on billing step and cannot proceed', async () => {
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+    });
+  });
+
   test('User cannot proceed to checkout with billing email not filled (#105)', async ({ page }) => {
     const mainPage = new MainPage(page);
     let productPage: ProductPage;


### PR DESCRIPTION
## Summary

- Added `billingAddress1Error` element to `CheckoutPage` (selector: `[data-valmsg-for="BillingNewAddress.Address1"]`)
- Added test: _User cannot proceed to checkout with billing address1 not filled (#108)_
- 3 tests passing across all browsers (chromium, firefox, webkit)

## Test Results

✓ 3/3 tests passing (chromium, firefox, webkit)

## Related Issues

Fixes #108

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)