### PR TITLE
feat: Add test for checkout with address1 not filled but address2 fil…

### DIFF
--- a/pages/checkoutpage.ts
+++ b/pages/checkoutpage.ts
@@ -19,6 +19,7 @@ class CheckoutPage {
     billingStateSelect: () => this.page.locator('#BillingNewAddress_StateProvinceId'),
     billingCityInput: () => this.page.locator('#BillingNewAddress_City'),
     billingAddressInput: () => this.page.locator('#BillingNewAddress_Address1'),
+    billingAddress2Input: () => this.page.locator('#BillingNewAddress_Address2'),
     billingZipInput: () => this.page.locator('#BillingNewAddress_ZipPostalCode'),
     billingPhoneInput: () => this.page.locator('#BillingNewAddress_PhoneNumber'),
 
@@ -136,6 +137,7 @@ class CheckoutPage {
     state,
     city,
     address,
+    address2,
     zipCode,
     phone,
   }: {
@@ -147,6 +149,7 @@ class CheckoutPage {
     state?: string;
     city: string;
     address: string;
+    address2?: string;
     zipCode: string;
     phone: string;
   }) {
@@ -181,6 +184,11 @@ class CheckoutPage {
 
     await this.elements.billingCityInput().fill(city);
     await this.elements.billingAddressInput().fill(address);
+
+    if (address2) {
+      await this.elements.billingAddress2Input().fill(address2);
+    }
+
     await this.elements.billingZipInput().fill(zipCode);
     await this.elements.billingPhoneInput().fill(phone);
   }

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -1227,6 +1227,66 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User cannot proceed to checkout with billing address1 not filled but address2 filled (#109)', async ({
+    page,
+  }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let checkoutPage: CheckoutPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and proceed to checkout', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      await cartPage.proceedToCheckout();
+    });
+
+    await test.step('Fill billing address with address1 intentionally left empty but address2 filled', async () => {
+      checkoutPage = new CheckoutPage(page);
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+      await checkoutPage.fillBillingAddress({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: userEmail,
+        country: 'United States',
+        city: 'New York',
+        address: '',
+        address2: 'Apt 4B',
+        zipCode: '10001',
+        phone: '+1 (212) 555-0100',
+      });
+    });
+
+    await test.step('Attempt to proceed without address1 and verify error message appears', async () => {
+      await checkoutPage.elements.nextButton().click();
+      await expect(checkoutPage.elements.billingAddress1Error()).toBeVisible();
+      await expect(checkoutPage.elements.billingAddress1Error()).toContainText('Street address is required');
+    });
+
+    await test.step('Verify user remains on billing step and cannot proceed', async () => {
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+    });
+  });
+
   test('User cannot proceed to checkout with billing email not filled (#105)', async ({ page }) => {
     const mainPage = new MainPage(page);
     let productPage: ProductPage;


### PR DESCRIPTION
…led (fixes #109)

- Added billingAddress2Input element and address2 support in fillBillingAddress (pages/checkoutpage.ts)
- Added test spec mirroring #108's pattern, filling Address2 while leaving Address1 empty
- Verified "Street address is required" validation still fires when only Address2 is provided
- All 3 browsers passing