### PR TITLE
feat: Add test for checkout with phone number not filled (#110)

### DIFF
--- a/pages/checkoutpage.ts
+++ b/pages/checkoutpage.ts
@@ -47,6 +47,7 @@ class CheckoutPage {
     billingCountryError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.CountryId"]'),
     billingCityError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.City"]'),
     billingAddress1Error: () => this.page.locator('[data-valmsg-for="BillingNewAddress.Address1"]'),
+    billingPhoneError: () => this.page.locator('[data-valmsg-for="BillingNewAddress.PhoneNumber"]'),
 
     // Guest checkout button (shown when not logged in)
     checkoutAsGuestButton: () => this.page.locator('input.checkout-as-guest-button, input[value="Checkout as Guest"]'),

--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -1343,4 +1343,61 @@ test.describe('Buy product tests', () => {
       await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
     });
   });
+
+  test('User cannot proceed to checkout with billing phone number not filled (#110)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let checkoutPage: CheckoutPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and proceed to checkout', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      await cartPage.proceedToCheckout();
+    });
+
+    await test.step('Fill billing address with phone number intentionally left empty', async () => {
+      checkoutPage = new CheckoutPage(page);
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+      await checkoutPage.fillBillingAddress({
+        firstName: 'John',
+        lastName: 'Doe',
+        email: userEmail,
+        country: 'United States',
+        city: 'New York',
+        address: '123 Main Street',
+        zipCode: '10001',
+        phone: '',
+      });
+    });
+
+    await test.step('Attempt to proceed without phone number and verify error message appears', async () => {
+      await checkoutPage.elements.nextButton().click();
+      await expect(checkoutPage.elements.billingPhoneError()).toBeVisible();
+      await expect(checkoutPage.elements.billingPhoneError()).toContainText('Phone is required');
+    });
+
+    await test.step('Verify user remains on billing step and cannot proceed', async () => {
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+    });
+  });
 });


### PR DESCRIPTION
## Summary

- Added `billingPhoneError` selector to `pages/checkoutpage.ts`
- Added test spec in `tests/buyproduct.spec.ts` covering checkout with billing phone number left empty, asserting the validation error appears and the user cannot proceed past the billing step

## Test Results

✓ New test passing on chromium, firefox, and webkit
✓ Full `buyproduct.spec.ts` suite (23 tests) passing on chromium
✓ TypeScript compiles without errors

## Related Issues

Fixes #110

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)