### PR TITLE
feat: Add test for checkout shipping address matching provided address (#112)

### DIFF
--- a/tests/buyproduct.spec.ts
+++ b/tests/buyproduct.spec.ts
@@ -847,6 +847,84 @@ test.describe('Buy product tests', () => {
     });
   });
 
+  test('User can see the provided billing address on the shipping address page (#112)', async ({ page }) => {
+    const mainPage = new MainPage(page);
+    let productPage: ProductPage;
+    let cartPage: CartPage;
+    let checkoutPage: CheckoutPage;
+
+    await test.step('User logs in to the application', async () => {
+      await mainPage.userLogIn(userEmail, userPassword);
+      await expect(mainPage.elements.loggedInUserLink(userEmail)).toBeVisible();
+    });
+
+    await test.step('Navigate to Books and add first product to cart', async () => {
+      productPage = new ProductPage(page);
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      await productPage.addToCartWithQuantity(1);
+    });
+
+    await test.step('Verify product was added to cart', async () => {
+      await expect(productPage.elements.successMessage()).toContainText('added to your shopping cart');
+      await productPage.closeSuccessNotification();
+    });
+
+    await test.step('Navigate to cart and proceed to checkout', async () => {
+      cartPage = new CartPage(page);
+      await cartPage.openCart();
+      await expect(cartPage.elements.cartItems().first()).toBeVisible();
+      await cartPage.proceedToCheckout();
+    });
+
+    await test.step('Fill billing address with a distinct, identifiable address', async () => {
+      checkoutPage = new CheckoutPage(page);
+      await expect(checkoutPage.elements.billingFirstNameInput()).toBeVisible();
+      await checkoutPage.fillBillingAddress({
+        firstName: 'Jane',
+        lastName: 'Smith',
+        email: userEmail,
+        country: 'United States',
+        city: 'Boston',
+        address: '456 Oak Avenue',
+        zipCode: '02108',
+        phone: '+1 (617) 555-0199',
+      });
+    });
+
+    await test.step('Proceed to shipping step', async () => {
+      await checkoutPage.proceedToNextStep();
+    });
+
+    await test.step('Verify the provided billing address is visible on the shipping address page', async () => {
+      const shippingOption = checkoutPage.elements.shippingAddressSelect().locator('option', { hasText: 'Jane Smith' });
+      await expect(shippingOption).toContainText('456 Oak Avenue');
+      await expect(shippingOption).toContainText('Boston');
+      await expect(shippingOption).toContainText('02108');
+    });
+
+    await test.step('Proceed through remaining checkout steps', async () => {
+      await checkoutPage.proceedToNextStep();
+      await checkoutPage.selectShippingMethod('Ground');
+      await checkoutPage.proceedToNextStep();
+      await checkoutPage.selectPaymentMethod('Credit Card');
+      await checkoutPage.proceedToNextStep();
+      await checkoutPage.proceedToNextStep();
+    });
+
+    await test.step('Confirm the order', async () => {
+      await checkoutPage.confirmOrder();
+    });
+
+    await test.step('Verify order was successfully placed', async () => {
+      const isConfirmed = await checkoutPage.isOrderConfirmed();
+      expect(isConfirmed).toBeTruthy();
+      const orderNumber = await checkoutPage.getOrderNumber();
+      expect(orderNumber).toBeTruthy();
+    });
+  });
+
   test('User can add multiple products to cart and remove one (#92)', async ({ page }) => {
     const mainPage = new MainPage(page);
     let productPage: ProductPage;


### PR DESCRIPTION
## Summary

- Added test spec in `tests/buyproduct.spec.ts` covering checkout where a distinct, identifiable billing address (Jane Smith, 456 Oak Avenue, Boston 02108, United States) is entered, then asserts that same address is visible as an option in the shipping address dropdown before completing checkout

## Test Results

✓ New test passing on chromium, firefox, and webkit
✓ Full `buyproduct.spec.ts` suite (24 tests) passing on chromium
✓ TypeScript compiles without errors

## Related Issues

Fixes #112

## Checklist

- [x] All tests passing
- [x] Page objects follow project conventions (reused existing `shippingAddressSelect` selector, no new page object needed)
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)