### PR TITLE
feat: Add test for comparing multiple products (#145)

### DIFF
--- a/pages/compareproductspage.ts
+++ b/pages/compareproductspage.ts
@@ -1,0 +1,29 @@
+import { Page } from '@playwright/test';
+
+class CompareProductsPage {
+  readonly page: Page;
+
+  constructor(page: Page) {
+    this.page = page;
+  }
+
+  elements = {
+    productNameLinks: () => this.page.locator('.compare-products-table tr.product-name a'),
+    productPrices: () => this.page.locator('.compare-products-table tr.product-price td.a-center'),
+    removeButton: (index: number = 0) => this.page.locator('.compare-products-table .remove-button').nth(index),
+    clearListLink: () => this.page.locator('.clear-list'),
+    emptyListMessage: () => this.page.getByText('You have no items to compare.'),
+  };
+
+  async getComparedProductNames(): Promise<string[]> {
+    const names = await this.elements.productNameLinks().allTextContents();
+    return names.map((name) => name.trim());
+  }
+
+  async getComparedProductPrices(): Promise<string[]> {
+    const prices = await this.elements.productPrices().allTextContents();
+    return prices.map((price) => price.trim());
+  }
+}
+
+export default CompareProductsPage;

--- a/pages/productpage.ts
+++ b/pages/productpage.ts
@@ -29,6 +29,7 @@ class ProductPage {
     addToCartButton: () => this.page.locator("//input[contains(@id, 'add-to-cart-button')]"),
     availabilityLabel: () => this.page.locator('.stock .value'),
     emailAFriendButton: () => this.page.locator('.email-a-friend-button'),
+    addToCompareButton: () => this.page.locator('.add-to-compare-list-button'),
 
     // List view add-to-cart button (on category/listing page, scoped per item index)
     addToCartFromListViewButton: (index: number = 0) =>
@@ -103,6 +104,11 @@ class ProductPage {
 
   async clickEmailAFriend() {
     await this.elements.emailAFriendButton().click();
+    await this.page.waitForLoadState('domcontentloaded');
+  }
+
+  async clickAddToCompare() {
+    await this.elements.addToCompareButton().click();
     await this.page.waitForLoadState('domcontentloaded');
   }
 }

--- a/tests/other.spec.ts
+++ b/tests/other.spec.ts
@@ -1,4 +1,5 @@
 import { generateRandomEmail } from '../support/stringOperations';
+import CompareProductsPage from '../pages/compareproductspage';
 import EmailAFriendPage from '../pages/emailafriendpage';
 import { test, expect } from '@playwright/test';
 import ProductPage from '../pages/productpage';
@@ -66,6 +67,53 @@ test.describe('Other tests', () => {
     // Assert: Confirmation that the email was sent
     await test.step('Verify confirmation message that the email was sent', async () => {
       await expect(emailAFriendPage.elements.resultMessage()).toHaveText('Your message has been sent.');
+    });
+  });
+
+  test('User can add multiple products to the compare list (#145)', async ({ page }) => {
+    const productPage = new ProductPage(page);
+    const compareProductsPage = new CompareProductsPage(page);
+    let firstProductName: string;
+    let secondProductName: string;
+
+    // Arrange & Act: Add the first product to the compare list
+    await test.step('Navigate to Books and add the first product to the compare list', async () => {
+      await productPage.navigateToCategory('Books');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      firstProductName = (await productPage.elements.productTitle().innerText()).trim();
+      await productPage.clickAddToCompare();
+    });
+
+    // Assert: The first product is on the compare page
+    await test.step('Verify the first product appears on the compare products page', async () => {
+      await expect(page).toHaveURL(/compareproducts/);
+      const names = await compareProductsPage.getComparedProductNames();
+      expect(names).toContain(firstProductName);
+    });
+
+    // Act: Add a second, different product to the compare list
+    await test.step('Navigate to Computers and add a second product to the compare list', async () => {
+      await productPage.navigateToCategory('Computers');
+      await expect(productPage.elements.productLink(0)).toBeVisible();
+      await productPage.selectProductByIndex(0);
+      secondProductName = (await productPage.elements.productTitle().innerText()).trim();
+      await productPage.clickAddToCompare();
+    });
+
+    // Assert: Both products are listed side by side with their prices
+    await test.step('Verify both products are listed for comparison with their prices', async () => {
+      await expect(page).toHaveURL(/compareproducts/);
+
+      const names = await compareProductsPage.getComparedProductNames();
+      expect(names).toContain(firstProductName);
+      expect(names).toContain(secondProductName);
+
+      const prices = await compareProductsPage.getComparedProductPrices();
+      expect(prices).toHaveLength(names.length);
+      for (const price of prices) {
+        expect(price).toMatch(/\d+\.\d{2}/);
+      }
     });
   });
 });


### PR DESCRIPTION
## Summary

- Added `pages/compareproductspage.ts` for the `/compareproducts` page (product names, prices, remove/clear-list actions)
- Added `addToCompareButton` selector + `clickAddToCompare()` to `pages/productpage.ts`
- Added a test to `tests/other.spec.ts` (Excel test case `003-02`): adds two different products to the compare list from their detail pages and verifies both appear on `/compareproducts` with prices

## Test Results

✓ 6/6 passing in `tests/other.spec.ts` (chromium, firefox, webkit)
✓ Full suite: 147/147 passing, excluding the pre-existing `openGithubIssue.spec.ts` live-API issue (unrelated, tracked separately)

## Related Issues

Fixes #145

## Checklist

- [x] All new tests passing
- [x] Page objects follow project conventions
- [x] Test specs follow project patterns (AAA, test.step)
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)