### PR TITLE
fix: GitHub API test failing when response[0] has no assignee (#181)

### DIFF
--- a/tests/openGithubIssue.spec.ts
+++ b/tests/openGithubIssue.spec.ts
@@ -33,10 +33,17 @@ test.describe('GitHub API tests', () => {
     if (!Array.isArray(parsed)) throw new Error('Unexpected GitHub response');
     const response = parsed as GithubIssue[];
 
+    // /issues?state=all also returns pull requests and unassigned items (e.g. Dependabot,
+    // or PRs created before an assignee is set), so the assignee check must find a matching
+    // issue rather than assume response[0] has one — see issue #181.
+    const assignedIssue = response.find((issue) =>
+      issue.assignees?.some((assignee) => assignee.login === githubApiData.assignee),
+    );
+
     expect(issues.status()).toBe(200);
     expect(response[0].url).toEqual(expect.stringContaining(githubApiData.baseEndpoint));
     expect(response[0].title).toBeTruthy();
-    expect(response[0].assignees?.[0].login).toEqual(githubApiData.assignee);
+    expect(assignedIssue?.assignees?.[0].login).toEqual(githubApiData.assignee);
   });
 
   [{ name: 'Login and register' }, { name: 'Buy product' }, { name: 'Other' }].forEach(({ name }) => {


### PR DESCRIPTION
## Summary

- `/issues?state=all` returns pull requests too, and any recent unassigned issue/PR (Dependabot updates, or a PR created before assignment) can land at `response[0]`. In fact right now `response[0]` is PR #269, which has no assignee.
- Root-caused this rather than just applying the suggested workaround: this isn't Dependabot-specific — configuring Dependabot to auto-assign (the issue's other proposed fix) wouldn't have covered unassigned PRs like our own.
- Fixed `tests/openGithubIssue.spec.ts` to find the first issue that actually has `RobertPecz` as an assignee instead of assuming `response[0]` does.

## Test Results

✓ 153/153 passing across the full suite (chromium, firefox, webkit) — including this test, which was the one consistently-failing test throughout prior PRs this session.

## Related Issues

Fixes #181

## Checklist

- [x] All tests passing
- [x] TypeScript compiles without errors
- [x] No breaking changes to existing tests
- [x] Related GitHub issue(s) referenced

🤖 Generated with [Claude Code](https://claude.com/claude-code)